### PR TITLE
Connect frontend to Flask backend

### DIFF
--- a/composables/useAuth.js
+++ b/composables/useAuth.js
@@ -1,4 +1,3 @@
-import {jwtDecode} from "jwt-decode"
 
 export default () => {
     const useAuthToken = () => useState('auth_token')
@@ -23,12 +22,13 @@ export default () => {
     const login = ({ username, password }) => {
         return new Promise(async (resolve, reject) => {
             try {
-                const data = await $fetch('/api/auth/login', {
+                const form = new FormData()
+                form.append('username', username)
+                form.append('password', password)
+
+                const data = await useFetchApi('/api/users/login', {
                     method: 'POST',
-                    body: {
-                        username,
-                        password
-                    }
+                    body: form
                 })
 
                 setToken(data.access_token)
@@ -41,57 +41,24 @@ export default () => {
         })
     }
 
-    const refreshToken = () => {
-        return new Promise(async (resolve, reject) => {
-            try {
-                const data = await $fetch('/api/auth/refresh')
-
-                setToken(data.access_token)
-                resolve(true)
-            } catch (error) {
-                reject(error)
-            }
-        })
-    }
-
     const getUser = () => {
         return new Promise(async (resolve, reject) => {
             try {
-                const data = await useFetchApi('/api/auth/user')
+                const data = await useFetchApi('/api/users/me')
 
-                setUser(data.user)
+                setUser(data.data)
                 resolve(true)
             } catch (error) {
                 reject(error)
             }
         })
-    }
-
-    const reRefreshAccessToken = () => {
-        const authToken = useAuthToken()
-
-        if (!authToken.value) {
-            return
-        }
-
-        const jwt = jwtDecode(authToken.value)
-
-        const newRefreshTime = jwt.exp - 60000
-
-        setTimeout(async () => {
-            await refreshToken()
-            reRefreshAccessToken()
-        }, newRefreshTime);
     }
 
     const initAuth = () => {
         return new Promise(async (resolve, reject) => {
             setIsAuthLoading(true)
             try {
-                await refreshToken()
                 await getUser()
-
-                reRefreshAccessToken()
 
                 resolve(true)
             } catch (error) {
@@ -104,18 +71,10 @@ export default () => {
     }
 
     const logout = () => {
-        return new Promise(async (resolve, reject) => {
-            try {
-                await useFetchApi('/api/auth/logout', {
-                    method: 'POST'
-                })
-
-                setToken(null)
-                setUser(null)
-                resolve()
-            } catch (error) {
-                reject(error)
-            }
+        return new Promise(async (resolve) => {
+            setToken(null)
+            setUser(null)
+            resolve()
         })
     }
 

--- a/composables/useFetchApi.js
+++ b/composables/useFetchApi.js
@@ -1,8 +1,8 @@
 export default (url, options = {}) => {
     const { useAuthToken } = useAuth()
+    const config = useRuntimeConfig()
 
-
-    return $fetch(url, {
+    return $fetch(config.public.apiBase + url, {
         ...options,
         headers: {
             ...options.headers,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,6 +23,7 @@ export default defineNuxtConfig({
       rapidApiKey: process.env.NUXT_PUBLIC_RAPIDAPI_KEY,
       rapidApiHost: process.env.NUXT_PUBLIC_RAPIDAPI_HOST,
       rapidApiBaseUrl: process.env.NUXT_PUBLIC_RAPIDAPI_BASE_URL,
+      apiBase: process.env.API_BASE_URL || 'http://localhost:5000'
     }
 
   }


### PR DESCRIPTION
## Summary
- add API base URL to Nuxt config
- update fetch util to use API base
- adapt auth composable for Flask endpoints
- rename tweet composable endpoints and transform data from Flask

## Testing
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842c853cb508328a897eddfe0974520